### PR TITLE
add  Publish to GitHub Container Registry workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to GitHub Container Registry
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          docker build --progress plain -t minid:latest -f Dockerfile.minid .
+      - run: |
+          echo "$(date -u '+%Y%m%d%H%M%S')" > TAG_NAME
+          echo "TAG_NAME=$(cat TAG_NAME)"
+      - run: |
+          TAG_NAME=$(cat TAG_NAME)
+          cat Dockerfile.build | \
+          docker run -i --rm minid:latest minid -f - | \
+          docker build --progress plain -t "ghcr.io/${{ github.repository }}:${TAG_NAME}-build" -f - .
+      - run: |
+          TAG_NAME=$(cat TAG_NAME)
+          cat Dockerfile | \
+          docker run -i --rm minid:latest minid -f - | \
+          docker build --progress plain -t "ghcr.io/${{ github.repository }}:${TAG_NAME}" -f - .
+      - run: |
+          TAG_NAME=$(cat TAG_NAME)
+          cat Dockerfile.test | sed -e "s|<REPO_NAME>|ghcr.io/${{ github.repository }}|g" | sed -e "s|<TAG_NAME>|${TAG_NAME}|g" | docker build --progress plain -t "ghcr.io/${{ github.repository }}:test" -f - .
+      - run: |
+          docker run -e PORT=5959 -e USER=herokuishuser "ghcr.io/${{ github.repository }}:test"
+      - run: |
+          docker images "ghcr.io/${{ github.repository }}"
+          TAG_NAME=$(cat TAG_NAME)
+          docker login -u "${{ github.actor }}" -p "${{ secrets.CONTAINER_REGISTRY_TOKEN }}" ghcr.io
+          docker push "ghcr.io/${{ github.repository }}:${TAG_NAME}"
+          docker push "ghcr.io/${{ github.repository }}:${TAG_NAME}-build"

--- a/Dockerfile.minid
+++ b/Dockerfile.minid
@@ -1,2 +1,2 @@
-FROM golang:1.10-stretch
+FROM golang:1.15-buster
 RUN go get -u github.com/orisano/minid


### PR DESCRIPTION
github container registryにpublishするworkflowを追加しました

workflow及びimageを使えるようにするためにいくつか設定をお願いできればと思います
- Settings > Secretsから packages にread/write権限を付与したgithub Personal access tokensを `CONTAINER_REGISTRY_TOKEN` をkeyとして追加
- ビルド完了後、 https://github.com/miyucy?tab=package のherokuishmパッケージへ遷移→ページ右上にある `package settings` からpublicに設定していただく

※secrets.GITHUB_TOKEN は権限が足りない関係上publishには使えないようです